### PR TITLE
Refactoring around CurrencyNameValue

### DIFF
--- a/public/all.currencies.js
+++ b/public/all.currencies.js
@@ -1,10 +1,12 @@
+// TODO I think we might reconsider this to be part of the data.
+// or at least we will on client side, "rehydrate" our data store with these so they can evolve over time (e.g. for rates)
 window.CRYPTO_CURRENCIES = [
   {
     name: "bitcoin",
     family: "Bitcoin",
     color: "#fcb653",
-    current_rate: {
-      value: 0.000061,
+    rate: {
+      value: 0.0061,
       currency_name: "EUR"
     },
     units: [
@@ -26,7 +28,7 @@ window.CRYPTO_CURRENCIES = [
     name: "dogecoin",
     family: "Dogecoin",
     color: "#65d196",
-    current_rate: {
+    rate: {
       value: 0.000000001,
       currency_name: "EUR"
     },
@@ -43,7 +45,7 @@ window.CRYPTO_CURRENCIES = [
     name: "dash",
     family: "Dash",
     color: "#0e76aa",
-    current_rate: {
+    rate: {
       value: 0.00000003,
       currency_name: "EUR"
     },
@@ -60,7 +62,7 @@ window.CRYPTO_CURRENCIES = [
     name: "ethereum",
     family: "Ethereum",
     color: "#27d0e2",
-    current_rate: {
+    rate: {
       value: 0.000245,
       currency_name: "EUR"
     },
@@ -77,7 +79,7 @@ window.CRYPTO_CURRENCIES = [
     name: "ethereum-classic",
     family: "Ethereum",
     color: "#3ca569",
-    current_rate: {
+    rate: {
       value: 0.000008,
       currency_name: "EUR"
     },
@@ -94,7 +96,7 @@ window.CRYPTO_CURRENCIES = [
     name: "litecoin",
     family: "Litecoin",
     color: "#cccccc",
-    current_rate: {
+    rate: {
       value: 0.000044,
       currency_name: "EUR"
     },

--- a/src/components/CurrencyCounterValueConversion.js
+++ b/src/components/CurrencyCounterValueConversion.js
@@ -1,30 +1,29 @@
 //@flow
 import React, { PureComponent } from "react";
+import { connect } from "react-redux";
 import CurrencyUnitValue from "./CurrencyUnitValue";
-import { findUnit } from "./CurrencyNameValue";
+import { inferUnitValue } from "../data/currency";
 
 class CurrencyCounterValueConversion extends PureComponent<*> {
   props: {
-    fromCurrencyName: string,
-    toCurrencyName: string,
-    fromValue: number,
-    toValue: number
+    currencyName: string,
+    data: *
   };
   render() {
-    const { fromCurrencyName, toCurrencyName, fromValue, toValue } = this.props;
-    if (fromValue <= 0) return null;
-    const { unit: fromUnit } = findUnit(fromCurrencyName);
-    const { unit: toUnit } = findUnit(toCurrencyName);
-    const v1 = Math.pow(10, fromUnit.magnitude);
-    const v2 = Math.round(v1 * toValue / fromValue);
+    const { currencyName, data } = this.props;
+    const { unit } = inferUnitValue(data, currencyName);
+    const value = Math.pow(10, unit.magnitude);
+    const toUnitValue = inferUnitValue(data, currencyName, value, true);
     return (
       <span>
-        <CurrencyUnitValue unit={fromUnit} value={v1} />
+        <CurrencyUnitValue unit={unit} value={value} />
         {" ≈ "}
-        <CurrencyUnitValue unit={toUnit} value={v2} />
+        <CurrencyUnitValue {...toUnitValue} />
       </span>
     );
   }
 }
 
-export default CurrencyCounterValueConversion;
+export default connect(({ data }) => ({ data }), () => ({}))(
+  CurrencyCounterValueConversion
+);

--- a/src/components/CurrencyUnitValue.js
+++ b/src/components/CurrencyUnitValue.js
@@ -9,19 +9,13 @@ const nonBreakableSpace = " ";
 class CurrencyUnitValue extends PureComponent<{
   unit: Unit,
   value: number, // e.g. 10000 . for EUR it means €100.00
-  alwaysShowSign?: boolean, // do you want to show the + before the number (N.B. minus is always displayed)
-  showAllDigits?: boolean
+  alwaysShowSign?: boolean // do you want to show the + before the number (N.B. minus is always displayed)
 }> {
-  static defaultProps = {
-    alwaysShowSign: false,
-    showAllDigits: false
-  };
-
   render() {
-    const { unit, value, alwaysShowSign, showAllDigits } = this.props;
+    const { unit, value, alwaysShowSign } = this.props;
     const { magnitude, code } = unit;
     const floatValue = value / 10 ** magnitude;
-    const minimumFractionDigits = showAllDigits ? magnitude : 0;
+    const minimumFractionDigits = unit.showAllDigits ? magnitude : 0;
     const maximumFractionDigits = Math.max(
       minimumFractionDigits,
       Math.max(

--- a/src/components/DataTableOperation/index.js
+++ b/src/components/DataTableOperation/index.js
@@ -27,8 +27,6 @@ const getHash = (operation: Operation): string => {
   return hash;
 };
 
-// TODO migrate all the operations/List in this component.
-
 let DataTableOperationCount = 0;
 
 class DataTableOperation extends Component<*> {
@@ -126,9 +124,10 @@ class DataTableOperation extends Component<*> {
         title: "",
         renderCell: operation => (
           <CurrencyNameValue
-            currencyName={operation.reference_conversion.currency_name}
-            value={operation.reference_conversion.amount}
+            currencyName={operation.currency_name}
+            value={operation.amount}
             alwaysShowSign
+            countervalue
           />
         )
       },

--- a/src/containers/Account/AccountView.js
+++ b/src/containers/Account/AccountView.js
@@ -67,18 +67,14 @@ class AccountView extends Component<
                 <CardField
                   label={
                     <CurrencyCounterValueConversion
-                      fromCurrencyName={account.currency.name}
-                      toCurrencyName={
-                        account.reference_conversion.currency_name
-                      }
-                      fromValue={account.balance}
-                      toValue={account.reference_conversion.balance}
+                      currencyName={account.currency.name}
                     />
                   }
                 >
                   <CurrencyNameValue
-                    currencyName={account.reference_conversion.currency_name}
-                    value={account.reference_conversion.balance}
+                    currencyName={account.currency.name}
+                    value={account.balance}
+                    countervalue
                   />
                 </CardField>
               </Card>

--- a/src/containers/Dashboard/AccountCard.js
+++ b/src/containers/Dashboard/AccountCard.js
@@ -17,7 +17,6 @@ class AccountCard extends Component<*> {
   };
   render() {
     const { account, filter } = this.props;
-    const { reference_conversion } = account;
 
     const title = (
       <div>
@@ -42,8 +41,9 @@ class AccountCard extends Component<*> {
           </div>
           <div className="realcur">
             <CurrencyNameValue
-              currencyName={reference_conversion.currency_name}
-              value={reference_conversion.balance}
+              currencyName={account.currency.name}
+              value={account.balance}
+              countervalue
             />
           </div>
         </div>

--- a/src/containers/Dashboard/Currencies.js
+++ b/src/containers/Dashboard/Currencies.js
@@ -1,8 +1,12 @@
+//@flow
 import _ from "lodash";
+import { connect } from "react-redux";
 import React from "react";
 import PieChart from "./PieChart";
+import { inferUnitValue } from "../../data/currency";
+import type { Account } from "../../datatypes";
 
-function Currencies({ accounts }) {
+function Currencies({ accounts, data }: { accounts: Array<Account>, data: * }) {
   //compute currencies from accounts balance
   const computedCurrencies = _.reduce(
     accounts,
@@ -17,14 +21,18 @@ function Currencies({ accounts }) {
           counterValueBalance: 0
         };
       currencies[currency_name].balance += balance;
-      currencies[currency_name].counterValueBalance +=
-        account.reference_conversion.balance;
+      currencies[currency_name].counterValueBalance += inferUnitValue(
+        data,
+        currency_name,
+        balance,
+        true
+      ).value;
       return currencies;
     },
     {}
   );
 
-  let data = _.reduce(
+  const pieChartData = _.reduce(
     Object.keys(computedCurrencies),
     (currenciesList, currencies) => {
       currenciesList.push(computedCurrencies[currencies]);
@@ -35,9 +43,9 @@ function Currencies({ accounts }) {
 
   return (
     <div className="currencies">
-      <PieChart data={data} />
+      <PieChart data={pieChartData} />
     </div>
   );
 }
 
-export default Currencies;
+export default connect(({ data }) => ({ data }), () => ({}))(Currencies);

--- a/src/countervalue-units.js
+++ b/src/countervalue-units.js
@@ -164,5 +164,8 @@ const units: { [key: string]: Unit } = {
   ZMW: { name: "ZMW", code: "ZMW", symbol: "ZK", magnitude: 2 },
   WON: { name: "WON", code: "WON", symbol: "₩", magnitude: 2 }
 };
+for (let u in units) {
+  units[u].showAllDigits = true;
+}
 
 export default units;

--- a/src/currencies.js
+++ b/src/currencies.js
@@ -1,5 +1,9 @@
 //@flow
 import type { Currency } from "./datatypes";
+
+// FIXME DEPRECATED, we will have currencies in the data store because they can evolve over time
+console.warn("src/currencies.js is deprecated, use the data store currencies");
+
 const currencies: Array<Currency> = global.CRYPTO_CURRENCIES || [];
 if (currencies.length === 0) {
   console.error("No currencies available!");

--- a/src/data/TODO.md
+++ b/src/data/TODO.md
@@ -1,4 +1,0 @@
-- implement diff cache strategy, we might not always want to ajax pull again everything everytime
-
-ADVANCED
-- implement a more complex system that would load missing data. Exemple: if someone else creates a new account and an operation on it, we don't refresh our page but we just load something like that Operation view page, we need to be able to load missing linked account. We can take server's data, compare it with the schema, and if we have missing ids, we do cascading of API calls until everything is loaded...

--- a/src/data/api-spec.js
+++ b/src/data/api-spec.js
@@ -8,6 +8,9 @@ export type APISpec = {
 };
 type API = { [_: string]: APISpec };
 
+// TODO: how to express the response type per API with flowtype? same with input type
+// TODO: different cache strategy. for instance, it's ok to cache /accounts because not much things should change BUT it should still refresh in some cases. cache invalidation can be tricky so we don't want to think about this too early
+
 /**
  * This specifies the API and how it maps to the schema model
  */

--- a/src/data/currency.js
+++ b/src/data/currency.js
@@ -1,0 +1,58 @@
+//@flow
+import counterUnitValues from "../countervalue-units";
+import type { Currency, Unit } from "../datatypes";
+
+type UnitValue = { value: number, unit: Unit };
+
+type DataStore = {
+  entities: {
+    currencies: {
+      [_: string]: Currency
+    }
+  }
+};
+
+export function getCurrency(currencyName: string, data: DataStore): ?Currency {
+  return data.entities.currencies[currencyName];
+}
+
+export function inferUnitValue(
+  data: DataStore,
+  currencyName: string,
+  value: number = 0, // by default, value just would get ignored
+  countervalue: boolean = false // calculate and return the countervalue of the currency
+): UnitValue {
+  let unit;
+  // try to find a countervalues unit
+  if (currencyName in counterUnitValues) {
+    unit = counterUnitValues[currencyName];
+  } else {
+    // try to find a crypto currencies unit
+    const currency = getCurrency(currencyName, data);
+    if (currency) {
+      // TODO:
+      // this will depend on user pref (if you select mBTC vs BTC , etc..)
+      // we might have a redux store that store user prefered unit per currencyName
+      unit = currency.units[0];
+      if (countervalue) {
+        // countervalue was required instead
+        const { rate } = currency;
+        if (!rate) {
+          throw new Error(`currency "${currencyName}" have no rate`);
+        }
+        const counterUnitValue = counterUnitValues[rate.currency_name];
+        if (!counterUnitValue) {
+          throw new Error(
+            `countervalue "${rate.currency_name}" for currency "${currencyName}" not found`
+          );
+        }
+        value = Math.round(rate.value * value);
+        unit = counterUnitValue;
+      }
+    }
+  }
+  if (!unit) {
+    throw new Error(`currency "${currencyName}" not found`);
+  }
+  return { unit, value };
+}

--- a/src/data/mock-entities.js
+++ b/src/data/mock-entities.js
@@ -160,10 +160,6 @@ const genOperation = opts => {
     block: {},
     type,
     amount,
-    reference_conversion: {
-      currency_name: "EUR",
-      amount: Math.round(amount * 0.0005)
-    },
     fees: 23,
     account_id,
     senders: ["0xc5a96db085dda36ffbe390f455315d30d6d3dc52"],
@@ -421,11 +417,11 @@ export default {
       security_scheme: genSecurityScheme(),
       creation_time: 1508923040570,
       currency: "dogecoin",
-      balance: 325898317820,
+      balance: 3258983178200000,
       balance_history: {
-        yesterday: 118834846,
-        week: 0,
-        month: 182834846
+        yesterday: 0.6 * 3258983178200000,
+        week: 0.7 * 3258983178200000,
+        month: 0.9 * 3258983178200000
       },
       receive_address: "15rbHzwPeyb6yUfK8zyp7RUoDUznqoTrtx",
       reference_conversion: {
@@ -439,11 +435,11 @@ export default {
       security_scheme: genSecurityScheme(),
       creation_time: 1508923040570,
       currency: "dash",
-      balance: 99058831782,
+      balance: 99058831782000,
       balance_history: {
-        yesterday: 1182834846,
-        week: 118283484,
-        month: 2182834846
+        yesterday: 99058831782000,
+        week: 0.5 * 99058831782000,
+        month: 0
       },
       receive_address: "15rbHzwPeyb6yUfK8zyp7RUoDUznqoTrtx",
       reference_conversion: {

--- a/src/data/schema.js
+++ b/src/data/schema.js
@@ -45,6 +45,7 @@ export const Operation = new schema.Entity(
       // NB this is to reconnect a disconnected model.
       // that means it will suppose account_id is already loaded.
       // we need to do smart loading system for that.
+      // TODO i'm not sure if it's a good idea at all. schema better should reject the API because we can have runtime breaking cases ATM. ideally the API should yield the Account object in Operation
       account: account_id,
       currency: entity.currency_name
     })

--- a/src/datatypes.js
+++ b/src/datatypes.js
@@ -6,14 +6,19 @@ export type Unit = {
   name: string,
   code: string,
   symbol: string,
-  magnitude: number
+  magnitude: number,
+  showAllDigits?: boolean
 };
 
 export type Currency = {
   name: string,
   family: string,
   color: string,
-  units: Array<Unit>
+  units: Array<Unit>,
+  rate?: {
+    value: number,
+    currency_name: string
+  }
 };
 
 export type Account = *; // TODO


### PR DESCRIPTION
- deprecate src/currencies.js, use from store instead
- generic helper in data/currency.js
- drop account.reference_conversion, instead calculate using currency.rate
- unit now have optional showAllDigits
- CurrencyNameValue simplified, now accept a countervalue bool