### PR TITLE
freeze material-ui version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ledgerco": "github:LedgerHQ/ledger-node-js-api#tmp-no-dep-to-node-hid",
     "lodash": "^4.17.4",
     "material-design-icons": "^3.0.1",
-    "material-ui": "^1.0.0-beta.24",
+    "material-ui": "1.0.0-beta.24",
     "moment": "^2.19.1",
     "node-polyglot": "^2.2.2",
     "normalizr-gre": "^3.2.4",


### PR DESCRIPTION
 Material-ui just introduced a bug in 1.beta-27. The animation when exiting a modal was not played properly. 

We'd better freeze material-ui to a working version since we may get rid of it in the future.