### PR TITLE
fix RenderLoading in Account Creation Currencies

### DIFF
--- a/src/components/ModalLoading/index.js
+++ b/src/components/ModalLoading/index.js
@@ -1,6 +1,7 @@
 //@flow
 import React, { PureComponent } from "react";
 import SpinnerCard from "../spinners/SpinnerCard";
+import cx from "classnames";
 import { withStyles } from "material-ui/styles";
 
 const styles = {
@@ -11,11 +12,16 @@ const styles = {
   }
 };
 
-class ModalLoading extends PureComponent<*> {
+type Props = {
+  classes: { [_: $Keys<typeof styles>]: string },
+  className?: string
+};
+
+class ModalLoading extends PureComponent<Props> {
   render() {
-    const { classes } = this.props;
+    const { classes, className } = this.props;
     return (
-      <div className={classes.base}>
+      <div className={cx(classes.base, className)}>
         <SpinnerCard />
       </div>
     );

--- a/src/components/accounts/creation/AccountCreationCurrencies.js
+++ b/src/components/accounts/creation/AccountCreationCurrencies.js
@@ -164,9 +164,19 @@ class AccountCreationCurrencies extends Component<{
   }
 }
 
+const styleLoading = {
+  base: {
+    height: 440,
+    width: "auto"
+  }
+};
+const Loading = withStyles(styleLoading)(({ classes }) => (
+  <ModalLoading className={classes.base} />
+));
+
 export default connectData(withStyles(styles)(AccountCreationCurrencies), {
   queries: {
     currencies: CurrenciesQuery
   },
-  RenderLoading: ModalLoading
+  RenderLoading: Loading
 });


### PR DESCRIPTION
`AccountCreationCurrencies` used `ModalLoading` to render when the data is loading. But `ModalLoading` had `width` and `height` fixed and it was too big for this use case, creating an ugly overflow bar.

I made `ModalLoading` customizable with a `className` and use it in AccountCreationCurrencies