### PR TITLE
Ui improvements

### DIFF
--- a/src/components/MenuLink.js
+++ b/src/components/MenuLink.js
@@ -10,6 +10,9 @@ const styles = {
     fontSize: 11,
     fontWeight: 600,
     paddingLeft: 40
+  },
+  disabled: {
+    opacity: 0.2
   }
 };
 
@@ -18,6 +21,7 @@ class MenuLink extends Component<{
   to: string,
   exact?: boolean,
   strict?: boolean,
+  disabled?: boolean,
   classes: Object,
   className?: string,
   children: *,
@@ -32,6 +36,7 @@ class MenuLink extends Component<{
       color,
       children,
       overrides,
+      disabled,
       className,
       ...props
     } = this.props;
@@ -42,8 +47,11 @@ class MenuLink extends Component<{
             style={{
               color: color || "#27d0e2" //default FIXME from theme
             }}
-            className={classNames(classes.root, className)}
+            className={classNames(classes.root, className, {
+              [classes.disabled]: disabled
+            })}
             button
+            disabled={disabled}
             disableRipple
             selected={!!match}
             component={Link}

--- a/src/components/approve/EntityApprove.js
+++ b/src/components/approve/EntityApprove.js
@@ -1,5 +1,7 @@
 //@flow
 import React, { Component } from "react";
+import AccountsQuery from "api/queries/AccountsQuery";
+import PendingAccountsQuery from "api/queries/PendingAccountsQuery";
 import connectData from "restlay/connectData";
 import AbortConfirmation from "./AbortConfirmation";
 import AccountApprove from "../accounts/approve/AccountApprove";
@@ -16,7 +18,6 @@ import ApproveAccountMutation from "api/mutations/ApproveAccountMutation";
 import AbortAccount from "api/mutations/AbortAccountMutation";
 import ApproveOperationMutation from "api/mutations/ApproveOperationMutation";
 import AbortOperationMutation from "api/mutations/AbortOperationMutation";
-import PendingAccountsQuery from "api/queries/PendingAccountsQuery";
 import PendingOperationsQuery from "api/queries/PendingOperationsQuery";
 import OperationApprove from "../operations/approve/OperationApprove";
 
@@ -88,6 +89,8 @@ class EntityApprove extends Component<Props, State> {
             public_key: pubKey.toUpperCase()
           })
         );
+        await restlay.fetchQuery(new AccountsQuery());
+        await restlay.fetchQuery(new PendingAccountsQuery());
       } else if (entity === "operation") {
         await restlay.commitMutation(
           new ApproveOperationMutation({

--- a/src/components/menu/AccountsMenu.js
+++ b/src/components/menu/AccountsMenu.js
@@ -5,9 +5,6 @@ import { withStyles } from "material-ui/styles";
 import { withRouter } from "react-router";
 import { MenuList } from "material-ui/Menu";
 import MenuLink from "../MenuLink";
-import connectData from "restlay/connectData";
-import AccountsQuery from "api/queries/AccountsQuery";
-import CurrenciesQuery from "api/queries/CurrenciesQuery";
 
 import { listCurrencies } from "@ledgerhq/currencies";
 const allCurrencies = listCurrencies();
@@ -71,11 +68,4 @@ class AccountsMenu extends Component<{
   }
 }
 
-export default withRouter(
-  connectData(withStyles(styles)(AccountsMenu), {
-    queries: {
-      accounts: AccountsQuery,
-      currencies: CurrenciesQuery
-    }
-  })
-);
+export default withRouter(withStyles(styles)(AccountsMenu));

--- a/src/components/menu/Menu.js
+++ b/src/components/menu/Menu.js
@@ -1,5 +1,9 @@
 //@flow
 import React from "react";
+import AccountsQuery from "api/queries/AccountsQuery";
+import CurrenciesQuery from "api/queries/CurrenciesQuery";
+import type { Account } from "data/types";
+import connectData from "restlay/connectData";
 import PropTypes from "prop-types";
 import { MenuList } from "material-ui/Menu";
 import MenuLink from "../MenuLink";
@@ -54,13 +58,14 @@ function Menu(
   props: {
     location: *,
     match: *,
-    classes: { [_: $Keys<typeof styles>]: string }
+    classes: { [_: $Keys<typeof styles>]: string },
+    accounts: Array<Account>
   },
   context: {
     translate: Function
   }
 ) {
-  const { location, classes, match } = props;
+  const { location, classes, accounts, match } = props;
   const t = context.translate;
   return (
     <div className={classes.root}>
@@ -76,7 +81,10 @@ function Menu(
             {t("menu.dashboard")}
           </span>
         </MenuLink>
-        <MenuLink to={`${match.url}/new-operation`}>
+        <MenuLink
+          to={`${match.url}/new-operation`}
+          disabled={accounts.length === 0}
+        >
           <span className={classes.link}>
             <Plus className={classes.icon} />
             {t("menu.newOperation")}
@@ -98,7 +106,7 @@ function Menu(
 
       <h4 className={classes.h4}>Accounts</h4>
 
-      <AccountsMenu location={location} />
+      <AccountsMenu location={location} accounts={accounts} />
 
       <ModalRoute path="*/new-operation" component={NewOperationModal} />
     </div>
@@ -109,4 +117,14 @@ Menu.contextTypes = {
   translate: PropTypes.func.isRequired
 };
 
-export default withStyles(styles)(Menu);
+const RenderLoading = withStyles(styles)(({ classes }) => (
+  <div className={classes.root} />
+));
+
+export default connectData(withStyles(styles)(Menu), {
+  RenderLoading: RenderLoading,
+  queries: {
+    accounts: AccountsQuery,
+    currencies: CurrenciesQuery
+  }
+});

--- a/src/components/menu/PendingsMenuBadge.js
+++ b/src/components/menu/PendingsMenuBadge.js
@@ -25,6 +25,9 @@ class PendingsMenuBadge extends Component<*> {
   render() {
     const { accounts, operations, classes } = this.props;
     const count = accounts.length + operations.length;
+    if (count === 0) {
+      return false;
+    }
     return <span className={classes.base}>{count}</span>;
   }
 }


### PR DESCRIPTION
- disable the `new operation` button if no account is created
- hide pending request counter if it's 0
- fetch `PendingAccountQuery` and `AccountQuery` after approving so the UI updates ( eg in the Menu )